### PR TITLE
docs: 'validate-crds' and 'kind' modules documentation

### DIFF
--- a/kind/README.md
+++ b/kind/README.md
@@ -1,0 +1,111 @@
+# Kind Dagger Module
+
+## Overview
+
+The `Kind` Dagger module simplifies the creation and management of a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.io/). It automates the setup of a Kind cluster within a Dagger pipeline, allowing developers to test Kubernetes workloads, apply manifests, or debug clusters locally or in CI/CD environments. The module supports loading container images into the cluster, interacting with the cluster via a `k9s` terminal, and inspecting the cluster's container environment.
+
+## Features
+
+- **Kind Cluster Creation**: Sets up a local Kubernetes cluster using Kind (v0.25.0) in a Docker container.
+- **Customizable Configuration**: Supports specifying the Kubernetes version and cluster name.
+- **Container Image Loading**: Loads container images into the Kind cluster with proper annotations for Kubernetes compatibility.
+- **Interactive Debugging**: Provides a `k9s` terminal for exploring the cluster.
+- **Cluster Inspection**: Allows inspection of the container running the Kind cluster.
+- **Flexible Networking**: Configures the Kind cluster's API server port via a provided service endpoint.
+
+## Usage
+
+The module is initialized with required and optional parameters and provides methods to manage the Kind cluster, load images, and interact with the cluster.
+
+### Module Initialization
+
+```go
+kind := dag.Kind(
+    dockerSocket,
+    kindSvc,
+    version,
+    clusterName,
+)
+```
+
+- **dockerSocket** (required): A Dagger socket for Docker (e.g., `/var/run/docker.sock`).
+- **kindSvc** (required): A Dagger service with a TCP endpoint (e.g., `tcp://127.0.0.1:3000`) for the Kind cluster's API server.
+- **version** (optional): The Kubernetes version in `vx.y` format (e.g., `v1.25`). Must match an available Kind image for Kind v0.25.0. Defaults to Kind's default version if not specified.
+- **clusterName** (optional): The name of the Kind cluster. Defaults to `dagger-kubernetes-cluster`.
+
+### Methods
+
+#### `LoadContainerOnKind(container *dagger.Container, tag string) *dagger.Container`
+
+Loads a container image into the Kind cluster.
+
+- **Inputs**:
+  - `container`: The Dagger container to load into the cluster.
+  - `tag`: The tag for the image (e.g., `my-image`).
+- **Behavior**:
+  - Annotates the container with Kind-compatible metadata (`org.opencontainers.image.ref.name` and `io.containerd.image.name`).
+  - Exports the container as a tarball.
+  - Loads the tarball into the Kind cluster using `kind load image-archive`.
+- **Returns**: The updated Kind container.
+- **Note**: Use `imagePullPolicy: Never` in Kubernetes manifests for images loaded this way, as they are not hosted on a registry.
+
+#### `Knines() *dagger.Container`
+
+Launches a `k9s` terminal for interactive exploration of the Kind cluster.
+
+- **Behavior**: Opens a terminal session in the Kind container running `k9s`.
+- **Returns**: The Kind container with the `k9s` terminal session.
+- **Usage Example**: `dagger call --docker-socket=/var/run/docker.sock --kind-svc=tcp://127.0.0.1:3000 knines`
+
+#### `Inspect() *dagger.Container`
+
+Provides access to the Kind container's terminal for inspection.
+
+- **Behavior**: Opens a terminal session in the Kind container for debugging or inspection.
+- **Returns**: The Kind container with a terminal session.
+- **Usage Example**: `dagger call --docker-socket=/var/run/docker.sock --kind-svc=tcp://127.0.0.1:3000 inspect`
+
+#### `Test() *dagger.Container`
+
+A placeholder method for testing purposes.
+
+- **Behavior**: Returns a new container based on `node:20-alpine`. (Note: This method appears incomplete and may be intended for future development.)
+- **Returns**: A new Dagger container.
+
+### Configuration Details
+
+- **Kind Cluster Setup**:
+  - Uses Kind v0.25.0.
+  - Creates a cluster with a YAML configuration specifying the API server port.
+  - Installs `docker`, `kubectl`, `k9s`, and `curl` in an Alpine-based container.
+  - Deletes any existing cluster with the same name before creating a new one.
+  - Configures `kubectl` to connect to the cluster at `https://localhost:<port>`.
+
+- **Networking**:
+  - The `kindSvc` endpoint must use `tcp://127.0.0.1:<port>`, where `<port>` is between 1024 and 65535.
+  - The `/etc/hosts` file on the host must map `127.0.0.1` to `localhost`.
+
+- **Image Loading**:
+  - Images are annotated with Kind-compatible metadata and loaded as tarballs.
+  - The `docker.io/library/<tag>:latest` prefix is added to satisfy Kind's requirements, but the image is not pulled from a registry.
+
+### Command to execute
+
+By executing the following command, you get in return a container with kind installed.
+
+`dagger call --docker-socket=/var/run/docker.sock --kind-svc=tcp://127.0.0.1:3000 container`
+
+### Notes
+
+- Ensure the host's `/etc/hosts` includes `127.0.0.1 localhost` to avoid connection issues.
+- The port specified in `kindSvc` must be valid (1024–65535).
+- The `Test` method is currently a placeholder and may not provide meaningful functionality.
+- Use `imagePullPolicy: Never` for manifests using images loaded via `LoadContainerOnKind`.
+- Errors during cluster creation or image loading will cause the module to panic with descriptive messages.
+
+## Limitations
+
+- Requires a valid Docker socket and a properly configured `kindSvc` endpoint.
+- Only supports Kubernetes versions compatible with Kind v0.25.0.
+- The `Test` method is incomplete and may not function as expected.
+- Assumes the host environment has `/etc/hosts` configured correctly.

--- a/validate-crds/README.md
+++ b/validate-crds/README.md
@@ -1,0 +1,103 @@
+# ValidateCrds Dagger Module
+
+## Overview
+
+The `ValidateCrds` Dagger module automates the validation of Kubernetes Custom Resource Definitions (CRDs) and Custom Resources (CRs) in a local [Kind](https://kind.sigs.k8s.io/) cluster. It creates a Kind cluster, applies CRDs, and then applies CRs to ensure they are valid and compatible with the defined CRDs.
+
+## Features
+
+- **Kind Cluster Integration**: Leverages the `prefapp/daggerverse/kind` module to create and manage a local Kubernetes cluster using Kind.
+- **CRD Application**: Applies CRD manifests from a specified directory to the Kind cluster.
+- **CR Validation**: Applies CR manifests and validates them against the deployed CRDs.
+- **Customizable Kubernetes Version**: Allows specifying the Kubernetes version for the Kind cluster (optional).
+- **Directory-Based Input**: Accepts directories containing CRD and CR manifests, supporting nested directories for CRs.
+
+## Prerequisites
+
+- **CRD and CR Manifests**: Prepare directories with valid CRD and CR YAML/JSON files.
+
+## Usage
+
+The module is initialized with required and optional parameters and provides methods to apply CRDs, create CRs, and validate them.
+
+### Module Initialization
+
+```go
+validateCrds := dag.ValidateCrds(
+    dockerSocket,
+    kindSvc,
+    crdsDir,
+    crsDir,
+    version,
+)
+```
+
+- **dockerSocket**: A Dagger socket for Docker, required by `prefapp/daggerverse/kind.
+- **kindSvc**: A Dagger service for the Kind cluster, required by `prefapp/daggerverse/kind`.
+- **crdsDir**: A directory containing CRD manifest files (YAML/JSON).
+- **crsDir**: A directory containing CR manifest files, which can include nested directories.
+- **version** (optional): Specifies the Kubernetes version for the Kind cluster (e.g., `v1.30`). Defaults to the Kind module's default version if not provided.
+
+### Methods
+
+#### `CreateCRDS() *dagger.Container`
+
+Applies the CRD manifests from the provided `crdsDir` to the Kind cluster.
+
+- **Input**: Uses the `crdsDir` directory mounted to `/crds` in the Kind container.
+- **Behavior**: Executes `kubectl apply -f .` to apply all CRD manifests in the directory.
+- **Returns**: A Dagger container with the applied CRDs.
+
+#### `CreateCRS(ctr *dagger.Container) (string, error)`
+
+Applies CR manifests from the provided `crsDir` to the Kind cluster.
+
+- **Input**: 
+  - `ctr`: A Dagger container with CRDs already applied (typically the one returned by `CreateCRDS`).
+  - Uses the `crsDir` directory mounted to `/crs` in the container.
+- **Behavior**: Executes `kubectl apply -R -f .` to recursively apply all CR manifests in the directory and its subdirectories.
+- **Returns**: The `kubectl` command output as a string and any error encountered.
+
+#### `Validate() (string, error)`
+
+Combines `CreateCRDS` and `CreateCRS` to validate CRs against CRDs.
+
+- **Behavior**: 
+  1. Applies CRDs using `CreateCRDS`.
+  2. Applies CRs using `CreateCRS` on the resulting container.
+- **Returns**: The output of the CR application process and any error encountered.
+
+### Directory Structure Example
+
+```
+crds/
+├── crd1.yaml
+├── crd2.yaml
+crs/
+├── namespace1/
+│   ├── cr1.yaml
+│   ├── cr2.yaml
+├── namespace2/
+│   ├── cr3.yaml
+```
+
+- **crdsDir**: Contains CRD manifests (e.g., `crd1.yaml`, `crd2.yaml`).
+- **crsDir**: Contains CR manifests, optionally organized in subdirectories (e.g., `namespace1/cr1.yaml`).
+
+### Command to execute
+
+```bash
+dagger call \
+    --docker-socket=/var/run/docker.sock \
+    --kind-svc=tcp://127.0.0.1:3000 \
+    --version v1_32 \
+    --crds-dir ./crds \
+    --crs-dir ./crs \
+    validate
+```
+
+## Limitations
+
+- Requires a valid Docker socket and Kind service.
+- Only supports Kubernetes versions available in the Kind module.
+- Does not perform advanced validation beyond applying CRs (e.g., no schema validation).


### PR DESCRIPTION
We want to document these modules in order to get a quick view of their features and utilities.

- [x] 'validate-crds' documentation
- [x] 'kind' documentation