### PR TITLE
fix(firestartr-bootstrap): updated CRDs URL

### DIFF
--- a/firestartr-bootstrap/commands.go
+++ b/firestartr-bootstrap/commands.go
@@ -46,7 +46,7 @@ func (m *FirestartrBootstrap) CreateBridgeContainer(
 		).
 		WithExec([]string{
 			"curl",
-			"https://prefapp.github.io/gitops-k8s/index.yaml",
+			"https://raw.githubusercontent.com/firestartr-pro/docs/refs/heads/main/site/raw/core/crds/latest/index.yaml",
 			"-o",
 			"/tmp/crds.yaml",
 		}).


### PR DESCRIPTION
The deprecated CRDs URL is replaced with the current CRDs URL.