### PR TITLE
fix: Wrong label on step_by_step.sh

### DIFF
--- a/firestartr-bootstrap/step_by_step.sh
+++ b/firestartr-bootstrap/step_by_step.sh
@@ -332,7 +332,7 @@ if [ "$AUTO" = true ]; then
 
     ACTION="continue"
 else
-    ACTION=$(prompt_continue_skip_abort "Push organization state secrets (only for enterprise orgs)?")
+    ACTION=$(prompt_continue_skip_abort "Push organization state secrets (only for non-free orgs)?")
 fi
 
 case "$ACTION" in


### PR DESCRIPTION
Fix `Push secrets` step being label as "only for **enterprise** orgs" instead of "only for **non-free** orgs"