### PR TITLE
fix: pr verify main

### DIFF
--- a/update-claims-features/main.go
+++ b/update-claims-features/main.go
@@ -190,7 +190,7 @@ func (m *UpdateClaimsFeatures) UpdateAllClaimFeatures(
 
 	var returnedError error
 	if errorMsg != "" {
-		returnedError = fmt.Errorf(errorMsg)
+		returnedError = fmt.Errorf("%s", errorMsg)
 	}
 
 	return m.DeploymentSummaryToFile(ctx, summary), returnedError


### PR DESCRIPTION
The PR verify in the main branch is reporting an error.

It seams like the error is in the function call to `fmt.Errorf()` in the `update-claims-features/main.go` file.

```
Error: ./main.go:193:30: non-constant format string in call to fmt.Errorf
```