### PR TITLE
fix: cannot reference external type

### DIFF
--- a/validate-crds/main.go
+++ b/validate-crds/main.go
@@ -11,8 +11,6 @@ type ValidateCrds struct {
 	Crs *dagger.Directory
 }
 
-type Version string
-
 func New(
 	ctx context.Context,
 
@@ -37,14 +35,14 @@ func New(
 	// The Kubernetes version you want to install in the Kind cluster. Has to be
 	// one of the available ones in the current Kind version used.
 	// +optional
-	version dagger.KindVersion,
+	version string,
 
 ) *ValidateCrds {
 
 	opts := dagger.KindOpts{}
 
 	if version != "" {
-		opts.Version = version
+		opts.Version = dagger.KindVersion(version)
 	}
 
 	container := dag.Kind(dockerSocket, kindSvc, opts).Container()


### PR DESCRIPTION
```
11  : ┆ ┆ ModuleSource.asModule ERROR [0.6s]
11  : ┆ ┆ ! failed to add object to module "validate-crds": failed to validate type def: object "ValidateCrds" function "" arg "version" cannot reference external type from dependency module "kind"
10  : ┆ initializing module ERROR [0.6s]
10  : ┆ ! failed to add object to module "validate-crds": failed to validate type def: object "ValidateCrds" function "" arg "version" cannot reference external type from dependency module "kind"
8   : load module: . ERROR [0.7s]
8   : ! failed to serve module: failed to add object to module "validate-crds": failed to validate type def: object "ValidateCrds" function "" arg "version" cannot reference external type from dependency module "kind"
A new release of dagger is available: v0.19.7 → v0.19.10
To upgrade, see https://docs.dagger.io/install
https://github.com/dagger/dagger/releases/tag/v0.19.10
Error: failed to serve module: failed to add object to module "validate-crds": failed to validate type def: object "ValidateCrds" function "" arg "version" cannot reference external type from dependency module "kind" [traceparent:cc57b73a60e9fa58a2d84c6d80a253f7-f08c07cd7b49bc6d]
```

This is an already known error from v0.19.7.

The `New` function in a module cannot have dependencies on other modules' types.