### PR TITLE
fix: authenticate firestartr bootstrap dependencies

### DIFF
--- a/firestartr-bootstrap/README.md
+++ b/firestartr-bootstrap/README.md
@@ -310,10 +310,9 @@ You can run the individual commands that compose the bootstrap process separatel
 Create persistent volume:
 
 ```shell
-dagger --bootstrap-file="./Bootstrapfile.yaml" \
-       --credentials-secret="file:./Credentialsfile.yaml" \
-       call cmd-create-persistent-volume \
-       --volume-name "firestartr-init"
+dagger --bootstrap-file="file://./boot/BootstrapFile.yaml" \
+    --credentials-secret="file://./boot/CredentialsFile.yaml" \
+    call cmd-create-persistent-volume --volume-name "firestartr-init"
 ```
 
 This will create a persistent volume in dagger that will be used to cache resources between commands. Note the volume ID returned, as it will be needed in the commands that need it (it will be marked as `<your-volume-id>`, and will be the SHA outputed by this command).
@@ -322,8 +321,8 @@ This will create a persistent volume in dagger that will be used to cache resour
 Validate bootstrap configuration:
 
 ```shell
-dagger --bootstrap-file="./Bootstrapfile.yaml" \
-       --credentials-secret="file:./Credentialsfile.yaml" \
+dagger --bootstrap-file="file://./boot/BootstrapFile.yaml" \
+       --credentials-secret="file://./boot/CredentialsFile.yaml" \
        call cmd-validate-bootstrap
 ```
 
@@ -333,8 +332,8 @@ This will validate the bootstrap configuration files.
 Initialize secrets machinery:
 
 ```shell
-dagger --bootstrap-file="./Bootstrapfile.yaml" \
-       --credentials-secret="file:./Credentialsfile.yaml" \
+dagger --bootstrap-file="file://./boot/BootstrapFile.yaml" \
+       --credentials-secret="file://./boot/Credentialsfile.yaml" \
        call cmd-init-secrets-machinery \
        --kubeconfig="${HOME}/.kube" \
        --kind-svc=tcp://localhost:<your-kind-port>

--- a/firestartr-bootstrap/firestartr.go
+++ b/firestartr-bootstrap/firestartr.go
@@ -20,12 +20,16 @@ func (m *FirestartrBootstrap) RenderWithFirestartrContainer(
 	}
 	fmt.Printf("💡 💡 Claims Entries: %v\n", entries)
 
-	fsCtr, err := dag.Container().From(
-		fmt.Sprintf(
-			"ghcr.io/prefapp/gitops-k8s:%s_slim",
-			m.Bootstrap.Firestartr.OperatorVersion,
-		),
-	).
+	prefappBotPat := dag.SetSecret("prefapp-bot-pat", m.Creds.GithubApp.PrefappBotPat)
+
+	fsCtr, err := dag.Container().
+		WithRegistryAuth("ghcr.io", "prefapp-bot", prefappBotPat).
+		From(
+			fmt.Sprintf(
+				"ghcr.io/prefapp/gitops-k8s:%s_slim",
+				m.Bootstrap.Firestartr.OperatorVersion,
+			),
+		).
 		WithDirectory("/claims", claimsDir).
 		WithDirectory("/crs", crsDir).
 		WithDirectory("/config", m.CrsDotConfigDir).

--- a/firestartr-bootstrap/helm.go
+++ b/firestartr-bootstrap/helm.go
@@ -46,7 +46,7 @@ func (m *FirestartrBootstrap) BuildHelmValues(
 		Secret: Secret{
 			Type: "Opaque",
 			Data: map[string]string{
-				"GITHUB_APP_PEM_FILE": m.Creds.GithubAppOperator.Pem,
+				"GITHUB_APP_PEM_FILE": m.Creds.GithubApp.Pem,
 			},
 		},
 		Config: Config{
@@ -63,8 +63,8 @@ func (m *FirestartrBootstrap) BuildHelmValues(
 				}, ","),
 				"OPERATOR_NAMESPACE":               "default",
 				"OPERATOR_IGNORE_LEASE":            "true",
-				"GITHUB_APP_ID":                    m.Creds.GithubAppOperator.GhAppId,
-				"GITHUB_APP_INSTALLATION_ID":       m.Creds.GithubAppOperator.InstallationId,
+				"GITHUB_APP_ID":                    m.Creds.GithubApp.GhAppId,
+				"GITHUB_APP_INSTALLATION_ID":       m.Creds.GithubApp.InstallationId,
 				"PREFAPP_BOT_PAT":                  m.Creds.GithubApp.PrefappBotPat,
 				"NODE_TLS_REJECT_UNAUTHORIZED":     "0",
 				"ORG":                              m.GhOrg,

--- a/firestartr-bootstrap/validations.go
+++ b/firestartr-bootstrap/validations.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"dagger/firestartr-bootstrap/internal/dagger"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
@@ -140,7 +142,13 @@ func (m *FirestartrBootstrap) ValidateExistenceOfNeededImages(
 		m.Bootstrap.Firestartr.OperatorVersion,
 	)
 
-	err := validateExistenceOfImage(ctx, slimImage)
+	ghcrAuth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("prefapp-bot:%s", m.Creds.GithubApp.PrefappBotPat)))
+	registryConfig := dag.SetSecret(
+		"ghcr-config",
+		fmt.Sprintf(`{"auths":{"ghcr.io":{"auth":"%s"}}}`, ghcrAuth),
+	)
+
+	err := validateExistenceOfImage(ctx, slimImage, registryConfig)
 	if err != nil {
 		return err
 	}
@@ -152,7 +160,7 @@ func (m *FirestartrBootstrap) ValidateExistenceOfNeededImages(
 		m.Creds.CloudProvider.Name,
 	))
 
-	err = validateExistenceOfImage(ctx, fullImage)
+	err = validateExistenceOfImage(ctx, fullImage, registryConfig)
 	if err != nil {
 		return err
 	}
@@ -164,24 +172,24 @@ func (m *FirestartrBootstrap) ValidateExistenceOfNeededImages(
 func validateExistenceOfImage(
 	ctx context.Context,
 	imageRef string,
+	registryToken *dagger.Secret,
 ) error {
 
 	// Use an image that has the 'crane' tool (from Google's container-registry tools)
 	craneContainer := dag.Container().
-		From("gcr.io/go-containerregistry/crane:latest")
-
-	craneArgs := []string{
-		"crane",
-		"manifest",
-		imageRef,
-	}
+		From("gcr.io/go-containerregistry/crane:latest").
+		WithEnvVariable("IMAGE_REF", imageRef).
+		WithMountedSecret("/root/.docker/config.json", registryToken)
 
 	_, err := craneContainer.
-		WithExec(craneArgs).
+		WithExec(
+			[]string{"manifest", "$IMAGE_REF"},
+			dagger.ContainerWithExecOpts{UseEntrypoint: true, Expand: true},
+		).
 		Stdout(ctx)
 
 	if err != nil {
-		return fmt.Errorf("image does not exist: %s", imageRef)
+		return fmt.Errorf("image does not exist or is not accessible: %s: %w", imageRef, err)
 	}
 
 	return nil
@@ -227,6 +235,7 @@ func (m *FirestartrBootstrap) ValidateOperatorPat(
 
 	base := dag.Container().From("alpine/curl").
 		WithExec([]string{"apk", "add", "jq"}).
+		WithEnvVariable("BUST_CACHE", time.Now().String()).
 		WithSecretVariable("GITHUB_PAT", tokenSecret)
 
 	// Add jq to extract the 'login' field


### PR DESCRIPTION
## Summary
- Authenticate private `ghcr.io/prefapp/gitops-k8s` pulls during bootstrap rendering with `prefappBotPat`.
- Authenticate image validation by mounting a Docker auth config for `crane manifest`.
- Use bootstrap/admin GitHub App credentials for the temporary init operator pod during bootstrap.

Fixes #464